### PR TITLE
This should not happen in an initializer. An initializer is just executed

### DIFF
--- a/lib/coffee/rails/railtie.rb
+++ b/lib/coffee/rails/railtie.rb
@@ -1,7 +1,5 @@
 module Coffee::Rails
   class Railtie < ::Rails::Railtie
-    initializer :setup_coffee do
-      config.app_generators.javascript_engine 'coffee'
-    end
+    config.app_generators.javascript_engine :coffee
   end
 end


### PR DESCRIPTION
This should not happen in an initializer. An initializer is just executed after config/application.rb is read. This means this would override whatever default set by the user. This commit fix it.
